### PR TITLE
Add language auto-detection

### DIFF
--- a/script.py
+++ b/script.py
@@ -3309,6 +3309,7 @@ if gradio_enabled is True:
                         gen_lang = gr.Dropdown(
                             value=config.api_def.api_language,
                             choices=[
+                                "auto",
                                 "ar",
                                 "zh",
                                 "cs",

--- a/system/requirements/requirements_colab.txt
+++ b/system/requirements/requirements_colab.txt
@@ -46,3 +46,4 @@ piper-tts; sys_platform == "linux"
 plotly==5.24.1
 scipy==1.14.1
 pyOpenSSL>=24.2.1
+langdetect>=1.0.9

--- a/system/requirements/requirements_standalone.txt
+++ b/system/requirements/requirements_standalone.txt
@@ -36,3 +36,4 @@ fastapi==0.112.2
 plotly==5.24.1
 scipy==1.14.1
 pyOpenSSL>=24.2.1
+langdetect>=1.0.9

--- a/system/requirements/requirements_textgen.txt
+++ b/system/requirements/requirements_textgen.txt
@@ -33,3 +33,4 @@ piper-phonemize==1.1.0; sys_platform == "darwin"
 plotly==5.24.1
 scipy==1.14.1
 pyOpenSSL>=24.2.1
+langdetect>=1.0.9


### PR DESCRIPTION
* adds langdetect as requirement for colab, standalone and textgen
* adds "auto" to the language dropdown in the Advanced Engine/Model Settings panel
* replace the hardcoded "en" by "auto" when called by the OpenAI compatible Speech API